### PR TITLE
Fixes for typo in rental pdf and adds Id file in Download Documents. Pdf was adjust to fit long texts.

### DIFF
--- a/pennydjango/leases/views.py
+++ b/pennydjango/leases/views.py
@@ -826,6 +826,11 @@ class GenerateRentalPDF(ClientOrAgentRequiredMixin,
                 .no-border {
                     border-bottom: 0px;
                 }
+                .long-text {
+                    table-layout:fixed;
+                    word-wrap: break-word;
+                    white-space: initial;
+                }
             ''',
             font_config=font_config
         )

--- a/pennydjango/leases/views.py
+++ b/pennydjango/leases/views.py
@@ -514,7 +514,6 @@ class ClientLease(ClientOrAgentRequiredMixin,
                 instance=rental_app
             )
             context['rental_docs'] = rental_app.rentalappdocument_set.all()
-            
         return context
 
 

--- a/pennydjango/leases/views.py
+++ b/pennydjango/leases/views.py
@@ -514,6 +514,7 @@ class ClientLease(ClientOrAgentRequiredMixin,
                 instance=rental_app
             )
             context['rental_docs'] = rental_app.rentalappdocument_set.all()
+            
         return context
 
 
@@ -702,6 +703,7 @@ class RentalApplicationDetail(ClientOrAgentRequiredMixin,
         context = super().get_context_data(**kwargs)
         context['lease_member'] = self.object.lease_member
         context['rental_docs'] = self.object.rentalappdocument_set.all()
+        context['id_file'] = self.object.id_file
         return context
 
 
@@ -731,7 +733,11 @@ class DownloadRentalDocuments(ClientOrAgentRequiredMixin,
             fdir, fname = os.path.split(doc.file.path)
             zip_path = os.path.join(zip_subdir, fname)
             zipf.write(doc.file.path, zip_path)
-
+        
+        id_file = rental_app.id_file
+        fdir, fname = os.path.split(id_file.path)
+        zip_path = os.path.join(zip_subdir, fname)
+        zipf.write(id_file.path, zip_path)
         zipf.close()
 
         response = HttpResponse(

--- a/pennydjango/templates/leases/rental_app/rental_app_detail.html
+++ b/pennydjango/templates/leases/rental_app/rental_app_detail.html
@@ -5,7 +5,7 @@
 {% block inner_content %}
   <h4 class="text-center">{{ lease_member.get_full_name }}</h4>
   <div class="text-center">
-    {% if rental_docs %}
+    {% if rental_docs or id_file %}
       <a type="button" class="btn btn-primary" href="{% url 'leases:rental-download' pk=object.id %}">
         Download Documents
       </a>

--- a/pennydjango/templates/leases/rental_app/rental_app_pdf.html
+++ b/pennydjango/templates/leases/rental_app/rental_app_pdf.html
@@ -65,7 +65,7 @@
     <caption colspan="3" style="padding:0px 20px 15px 23px">Personal Information:</caption>
     <tr>
       <td class="field-name">Name:</td>
-      <td style="width:66%;">{{ rental_app.nme|default_if_none:"" }}</td>
+      <td style="width:66%;">{{ rental_app.name|default_if_none:"" }}</td>
       <td class="field-name left-space">Date of Birth:</td>
       <td style="width:47%;">
         <span> {{ rental_app.date_of_birth|default_if_none:"" }}</span>
@@ -77,9 +77,9 @@
     <tbody>
     <tr>
       <td class="field-name top-space">SSN#:</td>
-      <td class="top-space" style="width:61%;">{{ rental_app.ss|default_if_none:"" }}</td>
+      <td class="top-space" style="width:61%;">{{ rental_app.ssn|default_if_none:"" }}</td>
       <td class="field-name left-space top-space">Phone:</td>
-      <td class="top-space" style="width:77%;">{{ rental_app.phne|default_if_none:"" }}</td>
+      <td class="top-space" style="width:77%;">{{ rental_app.phone|default_if_none:"" }}</td>
     </tr>
     </tr>
      </tbody>
@@ -87,9 +87,9 @@
     <tbody>
     <tr>
       <td class="field-name top-space">Email:</td>
-      <td class="top-space" style="width:68%;">{{ rental_app.emil|default_if_none:"" }}</td>
+      <td class="top-space" style="width:68%;">{{ rental_app.email|default_if_none:"" }}</td>
       <td class="field-name left-space top-space">Number of Pets:</td>
-      <td class="top-space" style="width:35%;">{{ rental_app.n_ofpets|default_if_none:"" }}</td>
+      <td class="top-space" style="width:35%;">{{ rental_app.n_of_pets|default_if_none:"" }}</td>
     </tr>
   </tbody>
 </table>
@@ -171,7 +171,7 @@
    <tbody>
     <tr>
       <td class="field-name top-space">Date:</td>
-      <td class="top-space" style="width:90.7%;">{{ rental_app.date|default_if_none:"" }}</td>
+      <td class="top-space" style="width:90.7%;">{% now "F j, Y" %}</td>
     </tr>
   </tbody>
 </table>

--- a/pennydjango/templates/leases/rental_app/rental_app_pdf.html
+++ b/pennydjango/templates/leases/rental_app/rental_app_pdf.html
@@ -77,7 +77,7 @@
     <tbody>
     <tr>
       <td class="field-name top-space">SSN#:</td>
-      <td class="top-space" style="width:61%;">{{ rental_app.ssn|default_if_none:"" }}</td>
+      <td class="top-space" style="width:59%;">{{ rental_app.ssn|default_if_none:"" }}</td>
       <td class="field-name left-space top-space">Phone:</td>
       <td class="top-space" style="width:77%;">{{ rental_app.phone|default_if_none:"" }}</td>
     </tr>
@@ -87,7 +87,7 @@
     <tbody>
     <tr>
       <td class="field-name top-space">Email:</td>
-      <td class="top-space" style="width:68%;">{{ rental_app.email|default_if_none:"" }}</td>
+      <td class="top-space" style="width:62%;">{{ rental_app.email|default_if_none:"" }}</td>
       <td class="field-name left-space top-space">Number of Pets:</td>
       <td class="top-space" style="width:35%;">{{ rental_app.n_of_pets|default_if_none:"" }}</td>
     </tr>
@@ -123,9 +123,25 @@
     <tbody>
     <tr>
       <td class="field-name top-space">Property Owner Name:</td>
-      <td class="top-space" style="width:70%;">{{ rental_app.landlord_name|default_if_none:"" }}</td>
-      <td class="field-name left-space top-space">Property Owner Contact:</td>
-      <td class="top-space" style="width:41%;">{{ rental_app.landlord_contact|default_if_none:"" }}</td>
+      <td class="top-space long-text" 
+        style="{% if rental_app.landlord_name|length > 39 %}
+            width:80%;
+          {% else %}
+            width:70%;
+          {% endif %}">{{ rental_app.landlord_name|default_if_none:"" }}</td>
+    {% if rental_app.landlord_name|length > 39 or rental_app.landlord_contact|length > 48 %}
+      </tr>
+      <tr>
+      <td class="field-name top-space">Property Owner Contact:</td>
+    {% else %}
+      <td class="field-name top-space left-space" style="padding-left: 22px;">Property Owner Contact:</td>
+    {% endif %}
+      <td class="top-space long-text" 
+        style="{% if rental_app.landlord_name|length > 39 or rental_app.landlord_contact|length > 48 %}
+          width:80%;
+          {% else %}
+          width:11%;
+        {% endif %}">{{ rental_app.landlord_contact|default_if_none:"" }}</td>
     </tr>
   </tbody>
 </table>
@@ -135,9 +151,9 @@
     <caption style="padding:0px 20px 15px 23px">Employment Information:</caption>
     <tr>
       <td class="field-name">Employer:</td>
-      <td style="width:50%;">{{ rental_app.current_company|default_if_none:"" }}</td>
+      <td class="long-text" style="width:50%;">{{ rental_app.current_company|default_if_none:"" }}</td>
       <td class="field-name left-space">Job title:</td>
-      <td style="width:30%;">{{ rental_app.job_title|default_if_none:"" }}</td>
+      <td class="long-text" style="width:30%;">{{ rental_app.job_title|default_if_none:"" }}</td>
     </tr>
     </tbody>
 </table>
@@ -145,7 +161,12 @@
     <tbody>
     <tr>
       <td class="field-name top-space">How long have you worked there:</td>
-      <td class="top-space" style="width:46%;">{{ rental_app.time_at_current_job|default_if_none:"" }}</td>
+      <td class="top-space long-text"
+        style="{% if rental_app.time_at_current_job|length > 31 %}
+            width:76%;
+          {% else %}
+            width:46%;
+          {% endif %}">{{ rental_app.time_at_current_job|default_if_none:"" }}</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
- This is the Pdf send by Joshua

![Joshua pdf](https://user-images.githubusercontent.com/8622012/89604228-73242580-d830-11ea-9d47-e9a23ef5e6cd.jpeg)

- This is how the pdf would look now with long texts:

[carocliente-carocliente-long text.pdf](https://github.com/apmilen/homenet/files/5039092/carocliente-carocliente-long.text.pdf)
![image](https://user-images.githubusercontent.com/8622012/89604344-b088b300-d830-11ea-93a8-5425e0091d6b.png)

- And with regular text:

[carocliente-carocliente-regular text.pdf](https://github.com/apmilen/homenet/files/5039094/carocliente-carocliente-regular.text.pdf)
![image](https://user-images.githubusercontent.com/8622012/89604408-d2823580-d830-11ea-93b3-de807441fc88.png)

